### PR TITLE
Grimdark Future v2.12

### DIFF
--- a/Grimdark_Future.gst
+++ b/Grimdark_Future.gst
@@ -771,10 +771,10 @@
 
 At the beginning of any round after the first you may place the model anywhere on the table over 9” away from enemy units.
 
-If both players have units with Ambush they must roll-off to see who deploys first.</description>
+If both players have units with Ambush they must roll-off to see who deploys first, and then alternate in placing them.</description>
     </rule>
     <rule id="1875-13ee-b0ef-5a65" name="Anti-Air" publicationId="d755-5d69-pubN65537" hidden="false">
-      <description>When shooting at enemy Aircraft models firing this weapon don’t count as being an extra 12” away and don’t get –1 to hit rolls.</description>
+      <description>When shooting at enemy Aircraft models firing this weapon don’t count as being an extra 12” away and don’t get the penalty of -1 to hit rolls.</description>
     </rule>
     <rule id="f84f-fda5-e478-455d" name="AP(X)" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Enemy units taking hits from weapons with this special rule get -X to Defense rolls.</description>
@@ -806,7 +806,7 @@ Note that wounds suffered by that model don’t carry over to other models if it
       <description>Whenever a model with this special rule charges it deals X automatic hits.</description>
     </rule>
     <rule id="587a-b92c-a265-06c4" name="Indirect" publicationId="d755-5d69-pubN65537" hidden="false">
-      <description>Weapons with this special rule may shoot at enemies that are not within line of sight, however they get –1 to hit when shooting after moving.</description>
+      <description>Weapons with this special rule may shoot at enemies that are not in line of sight and ignore cover from sight obstructions, however they get -1 to hit when shooting after moving.</description>
     </rule>
     <rule id="2c45-0e1e-fec5-8dbb" name="Poison" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Whenever you roll an unmodified to hit result of 6 whilst firing this weapon that hit is multiplied by 3.</description>
@@ -814,30 +814,30 @@ Note that wounds suffered by that model don’t carry over to other models if it
     <rule id="ba47-b43b-18f8-97c1" name="Psychic(X)" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Models with this special rule may cast one spell at any point during their activation before attacking.
 
-To cast a spell pick one from the psychic’s army list, pick a target in line of sight, and roll D6+X. If the result is equal to or higher than the number in brackets then you may resolve the spell’s effects.
+To cast a spell select one from the psychic’s army list, pick a target in line of sight, and roll D6+X. If the result is equal to or higher than the number in brackets then you may resolve the spell’s effects.
 
 Enemy psychics within 18” and line of sight may also roll D6+X at the same time, and if the result is higher than that of the casting psychic, then the spell’s effects are blocked instead.
 
-Note that a psychic may only either try to cast a spell or try to block a spell each round.</description>
+Note that each psychic may only either try to cast a spell or try to block a spell each round.</description>
     </rule>
     <rule id="dea8-a8f9-1865-4424" name="Regeneration" publicationId="d755-5d69-pubN65537" hidden="false">
-      <description>Whenever this model takes wounds roll one die for each. On a 5+ the wound is ignored.</description>
+      <description>Whenever this model takes wounds, roll one die for each. On a 5+ the wound is ignored.</description>
     </rule>
     <rule id="9726-accd-9015-f6f6" name="Rending" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Whenever you roll an unmodified to hit result of 6 whilst using this weapon that hit counts as having AP(4) and it ignores the Regeneration rule.</description>
     </rule>
     <rule id="7bc7-a892-49bc-ad88" name="Scout" publicationId="d755-5d69-pubN65537" hidden="false">
-      <description>After all other units have been deployed models with scout may deploy within 24” of the player’s table edge (instead of 12”).
+      <description>After all other units have been deployed models with scout may be deployed and then moved by up to 12”, ignoring terrain.
 
-If both players have units with Scout they must roll-off to see who deploys first.</description>
+If both players have units with Scout they must roll-off to see who goes first, and then alternate in placing them.</description>
     </rule>
     <rule id="394b-1b64-d270-f49e" name="Slow" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Units with this special rule move 4” when using Advance actions and 8” when using Rush or Charge actions.</description>
     </rule>
     <rule id="2943-e3f6-fb44-ae13" name="Sniper" publicationId="d755-5d69-pubN65537" hidden="false">
-      <description>Models firing this weapon count as having Quality 2+ when rolling to hit.
+      <description>Models firing weapons with this special rule count as having Quality 2+ when rolling to hit, and the attacker may pick one model from the target unit as its target.
 
-This weapon ignores cover and the attacker may pick which model from the target unit is hit when shooting.</description>
+Note that shooting is resolved as if the target was a unit of 1.</description>
     </rule>
     <rule id="1b59-5d31-4675-c926" name="Stealth" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Enemies targeting this unit get –1 to hit when shooting at it.</description>
@@ -850,7 +850,9 @@ This weapon ignores cover and the attacker may pick which model from the target 
 
 If a model with Tough joins a unit without it then you must remove regular models as casualties before starting to accumulate wounds on the model with Tough.
 
-When a unit with multiple Tough models takes wounds you must accumulate them on a single model until it is killed before starting to accumulate them on another.</description>
+When a unit with multiple Tough models takes wounds you must accumulate them on the tough model with most wounds until it is killed before starting to accumulate them on another.
+
+Note that heroes must still be assigned wounds last.</description>
     </rule>
     <rule id="3460-57e3-8a15-7977" name="Transport(X)" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Models with this special rule may transport up to X models in their cargo.
@@ -862,7 +864,7 @@ If a unit is inside of a Transport when it is destroyed then it must take a Dang
     <rule id="5065-c3a4-a9cf-db27" name="Hero" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>Models with this special rule may be deployed as part of one other friendly unit at the beginning of the game.
 
-When rolling morale tests units may use the hero’s Quality value and when rolling to block use the Defense of the hero&apos;s unit until all non-hero models are killed.</description>
+When rolling morale tests units may use the hero’s Quality value and when rolling to block use the Defense of the hero’s unit until all non-hero models are killed.</description>
     </rule>
     <rule id="187f-6a03-5b99-a4db" name="Aircraft" publicationId="d755-5d69-pubN65537" hidden="false">
       <description>These models fly far above the battlefield and can’t physically interact with any other models or terrain, nor can they be moved in base contact with.

--- a/Grimdark_Future.gst
+++ b/Grimdark_Future.gst
@@ -27,7 +27,7 @@
         <characteristicType id="7a54-240f-72ef-5022" name="Special Rules"/>
       </characteristicTypes>
     </profileType>
-    <profileType id="a964-43c6-d8f5-e47f" name="Upgrade">
+    <profileType id="a964-43c6-d8f5-e47f" name="Enhancement">
       <characteristicTypes>
         <characteristicType id="189e-687a-bec2-51ad" name="Special Rules"/>
       </characteristicTypes>
@@ -881,12 +881,12 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2432-e2b3-c2c4-9482" name="Psychic(1)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
+    <profile id="2432-e2b3-c2c4-9482" name="Psychic(1)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Enhancement">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(1)</characteristic>
       </characteristics>
     </profile>
-    <profile id="3e8c-01f9-834d-a443" name="Psychic(2)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
+    <profile id="3e8c-01f9-834d-a443" name="Psychic(2)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Enhancement">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(2)</characteristic>
       </characteristics>
@@ -1165,7 +1165,7 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Blast(3), Indirect</characteristic>
       </characteristics>
     </profile>
-    <profile id="264c-3d01-4b6d-fb09" name="Dozer Blade" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
+    <profile id="264c-3d01-4b6d-fb09" name="Dozer Blade" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Enhancement">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Strider</characteristic>
       </characteristics>
@@ -1219,7 +1219,7 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
-    <profile id="cdae-0f78-03a5-6bc8" name="Psychic(3)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
+    <profile id="cdae-0f78-03a5-6bc8" name="Psychic(3)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Enhancement">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(3)</characteristic>
       </characteristics>

--- a/Grimdark_Future.gst
+++ b/Grimdark_Future.gst
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="d755-5d69-2721-c11b" name="Grimdark Future" revision="19" battleScribeVersion="2.03" authorName="Scott Prutton" authorContact="sprutton1@gmail.com" authorUrl="https://github.com/sprutton1/GrimdarkFutureBattlescribe" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="d755-5d69-2721-c11b" name="Grimdark Future" revision="20" battleScribeVersion="2.03" authorName="Darguth" authorContact="" authorUrl="https://github.com/onepagerule/GrimdarkFuture" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
-    <publication id="d755-5d69-pubN65537" name="Grimdark Future v2.10"/>
+    <publication id="d755-5d69-pubN65537" name="Grimdark Future v2.12"/>
   </publications>
   <costTypes>
     <costType id="567f-6468-66c6-2ea2" name="pts" defaultCostLimit="-1.0" hidden="false"/>
@@ -27,7 +27,7 @@
         <characteristicType id="7a54-240f-72ef-5022" name="Special Rules"/>
       </characteristicTypes>
     </profileType>
-    <profileType id="a964-43c6-d8f5-e47f" name="Equipment">
+    <profileType id="a964-43c6-d8f5-e47f" name="Upgrade">
       <characteristicTypes>
         <characteristicType id="189e-687a-bec2-51ad" name="Special Rules"/>
       </characteristicTypes>
@@ -879,12 +879,12 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2432-e2b3-c2c4-9482" name="Psychic(1)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+    <profile id="2432-e2b3-c2c4-9482" name="Psychic(1)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(1)</characteristic>
       </characteristics>
     </profile>
-    <profile id="3e8c-01f9-834d-a443" name="Psychic(2)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+    <profile id="3e8c-01f9-834d-a443" name="Psychic(2)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(2)</characteristic>
       </characteristics>
@@ -1163,7 +1163,7 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Blast(3), Indirect</characteristic>
       </characteristics>
     </profile>
-    <profile id="264c-3d01-4b6d-fb09" name="Dozer Blade" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+    <profile id="264c-3d01-4b6d-fb09" name="Dozer Blade" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Strider</characteristic>
       </characteristics>
@@ -1217,7 +1217,7 @@ When an Aircraft is activated it must move a full 18” to 36” in a straight l
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
-    <profile id="cdae-0f78-03a5-6bc8" name="Psychic(3)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+    <profile id="cdae-0f78-03a5-6bc8" name="Psychic(3)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(3)</characteristic>
       </characteristics>

--- a/Human_Inquisition.cat
+++ b/Human_Inquisition.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="01fd-3d07-904a-c359" name="Human Inquisition" revision="5" battleScribeVersion="2.03" authorName="Darguth" authorContact="" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="01fd-3d07-904a-c359" name="Human Inquisition" revision="6" battleScribeVersion="2.03" authorName="Darguth" authorContact="" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="41ea-f39b-0c06-e87e" name="Human Inquisition v2.8"/>
   </publications>
@@ -170,7 +170,7 @@
         <profile id="1a5f-72c7-c4ee-f83d" name="Combat Knife" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
           <characteristics>
             <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
-            <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"></characteristic>
+            <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
           </characteristics>
         </profile>
       </profiles>
@@ -710,6 +710,9 @@
       <infoLinks>
         <infoLink id="0b65-1b6a-8de9-d911" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7c75-c9b4-0f3f-7c57" name="Show Spells" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -718,6 +721,9 @@
       <infoLinks>
         <infoLink id="5faf-de05-0e1a-75a7" name="Psychic Spells" hidden="false" targetId="5538-0c43-e9d4-b0b6" type="infoGroup"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -841,6 +847,13 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461b-85ed-8b65-377e" type="max"/>
               </constraints>
+              <profiles>
+                <profile id="6112-dfed-d2dd-4d4d" name="Forbidden Lore (Psychic(1))" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
+                  <characteristics>
+                    <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Psychic(1)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
               <infoLinks>
                 <infoLink id="17ca-9e20-9b10-647c" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
               </infoLinks>
@@ -868,7 +881,7 @@
           <selectionEntries>
             <selectionEntry id="efc3-e315-8035-f4ef" name="Alien Hunter" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="4e5a-d801-a134-a1bd" name="Alien Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                <profile id="4e5a-d801-a134-a1bd" name="Alien Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
                   <characteristics>
                     <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">The hero and his unit count as having the Furious rule.</characteristic>
                   </characteristics>
@@ -883,7 +896,7 @@
             </selectionEntry>
             <selectionEntry id="f32d-d730-41b6-e8ee" name="Daemon Hunter" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="dc1c-b317-4907-4207" name="Daemon Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                <profile id="dc1c-b317-4907-4207" name="Daemon Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
                   <characteristics>
                     <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Enemy units can’t use Ambush within 18” of the hero.</characteristic>
                   </characteristics>
@@ -895,7 +908,7 @@
             </selectionEntry>
             <selectionEntry id="6545-985f-a00d-8d34" name="Witch Hunter" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="52ce-2e7e-1f2f-164a" name="Witch Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                <profile id="52ce-2e7e-1f2f-164a" name="Witch Hunter" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Upgrade">
                   <characteristics>
                     <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">This model may block spells as if it had the Psychic(2) special rule. If it is a Psychic then it gets +2 to spell block rolls.</characteristic>
                   </characteristics>

--- a/readme.md
+++ b/readme.md
@@ -73,28 +73,28 @@ table!
 
 | Army | Version | Author|
 |---|---|---|
-|Game System|v2.10|Darguth|
-|Alien Hives|v2.9|Darguth|
+|Game System|v2.12|Darguth|
+|Alien Hives|v2.9|Kelbesq|
 |Battle Brothers|Main v2.12 - Prime v2.14 - Detachments v2.14|no active author|
 |Battle Sisters|v2.9|no active author|
 |Custodian Brothers|v2.1|no active author|
 |Dark Elf Raiders|v2.7|no active author|
 |Dwarf Guilds|v2.6|Darguth|
-|Elven Jesters|v2.7|Darguth|
-|Feudal Guard|v2.8|no active author|
+|Elven Jesters|v2.7|Risingstudios|
+|Feudal Guard|v2.8|strongbif|
 |Havoc Brothers|Main v2.11 - Disciples v2.15|no active author|
 |High Elf Fleets|v2.10|Darguth|
 |Human Defense Force|v2.13|Darguth|
 |Human Inquisition|2.8|Darguth|
 |Infected Colonies|v2.4|no active author|
-|Machine Cult|v2.10|Darguth|
-|Machine Cult Defilers|v2.5|no active author|
+|Machine Cult|v2.10|Kelbesq|
+|Machine Cult Defilers|v2.5|Kelbesq|
 |Orc Marauders|v2.12|Darguth|
 |Ratmen Clans|v2.6|no active author|
 |Rebel Guerrillas|v2.5|no active author|
-|Robot Legions|v2.12|no active author|
+|Robot Legions|v2.12|Risingstudios|
 |Soul-Snatcher Cults|v2.8|Darguth|
-|TAO Coalition|v2.11|Darguth|
+|TAO Coalition|v2.11|Kelbesq|
 |Titan Lords|v2.4|no active author|
 |Vile Rattus Cult|v2.5|no active author|
 |Wormhole Daemons|v2.9|no active author|


### PR DESCRIPTION
1. Updated common rules with latest wording.
2. Changed "Equipment" profile type to "Enhancement" for more general-purpose use. (Didn't use "Upgrade" because it then alphabetically sorts below the Unit profile type in the roster print out, which I didn't care for.)
3. Fixed a bug with a missing profile for the Inquisition v2.8 update I just did.